### PR TITLE
Replace unicode-segmentation with segtok

### DIFF
--- a/yake_rust/Cargo.toml
+++ b/yake_rust/Cargo.toml
@@ -55,7 +55,7 @@ zh = []
 regex = "1"
 streaming-stats = "0.2.3"
 contractions = "0.5.4"
-unicode-segmentation = "1.12.0"
+segtok = "0.1.0"
 levenshtein = "1.0.5"
 indexmap = "2.7.0"
 

--- a/yake_rust/src/preprocessor.rs
+++ b/yake_rust/src/preprocessor.rs
@@ -1,19 +1,47 @@
-use unicode_segmentation::UnicodeSegmentation;
+use segtok::segmenter::split_multi;
+use segtok::tokenizer::{split_contractions, web_tokenizer};
 
 pub fn split_into_words(text: &str) -> Vec<String> {
-    text.split_word_bounds()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .map(|s| s.replace("'s", "").replace(",", ""))
+    split_contractions(web_tokenizer(text))
+        .into_iter()
+        .filter(|word| !(word.is_empty() || word.len() > 1 && word.starts_with("'")))
         .collect()
 }
 
 pub fn split_into_sentences(text: &str) -> Vec<String> {
-    text.trim()
-        .replace("\n", "")
-        .replace("\t", "")
-        .replace("\r", "")
-        .unicode_sentences()
-        .map(ToString::to_string)
-        .collect()
+    split_multi(&text, Default::default()).into_iter().filter(|span| !span.is_empty()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_hyphenated_sentence_into_words() {
+        let text = "Truly high-tech!";
+        let expected = ["Truly", "high-tech", "!"];
+        let actual = split_into_words(&text);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn split_sentences() {
+        let text = "One smartwatch. One phone. Many phones.";
+        let expected = ["One smartwatch.", "One phone.", "Many phones."];
+        let actual = split_into_sentences(&text);
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn split_tabbed_multiline_text_into_sentences() {
+        let text = "This is your weekly newsletter! \
+            Hundreds of great deals - everything from men's fashion \
+            to high-tech drones!";
+        let expected = [
+            "This is your weekly newsletter!",
+            "Hundreds of great deals - everything from men's fashion to high-tech drones!",
+        ];
+        let actual = split_into_sentences(&text);
+        assert_eq!(actual, expected);
+    }
 }


### PR DESCRIPTION
Also fix alphanum and punctuation checks that were eliminating words with hyphens.

The alphanum check was allowing for hyphens in one place but not in another place, this caused "high-tech" to not be in "tf_nsw" and thus the mean, max, std TF to be incorrect. I used the pre-existing alphanum-or-hyphen function in all places. I did not verify this with LIAAD/yake, but without it, the results become bad.

The punctuation check was checking for if there were any punctuation symbols in the word, which meant that "high-tech" got eliminated since "-" is a punctuation symbol. However, LIAAD/yake checks if the whole word consists of punctuation symbols (https://github.com/LIAAD/yake/blob/0fa58cceb465162b6bd0cab7ec967edeb907fbcc/yake/datarepresentation.py#L59), so I changed has-punctuation to is-punctuation.

This caused the hyphenation parts of the tests to match LIAAD/yake, which I consider a step forward.

I am not sure why we have the same alphanum/punctuation checks in two places, or how it compares to LIAAD/yake.

It seems like we do not have an equivalent to LIAAD/yake's `pre_filter` function (https://github.com/LIAAD/yake/blob/0fa58cceb465162b6bd0cab7ec967edeb907fbcc/yake/datarepresentation.py#L118) which is applied to the text before splitting it into sentences and words. Might be worth considering. For the current tests, I think it does not matter because we do not have much newlines in the test inputs (not sure we have any, actually).

